### PR TITLE
train-model.yaml in README has tabs. Use spaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ spec:
   - name: model-logs
     persistentVolumeClaim:
       claimName: met-art-logs
-	imagePullSecrets:
-	- name: bluemix-secret
+  imagePullSecrets:
+  - name: bluemix-secret
   restartPolicy: Never
 ```
 


### PR DESCRIPTION
The example in the README has tabs which show up as red blocks and wrongly indented.  Use spaces.