### PR TITLE
Add path to generated env var for project

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,13 @@ $ cd /your_home_directory
 $ git clone https://github.com/IBM/tensorflow-kubernetes-art-classification.git
 ```
 
-The script to query Google BigQuery is `bigquery.py`. Edit the script to put in the appropriate SQL string
-above.  Update the project with the id from the previous step.
+The script to query Google BigQuery is `bigquery.py`. Edit the script to put the file path to the generated service account credentials done in the previous step of installing the client on your laptop to interact with Google BigQuery [instructions](https://cloud.google.com/bigquery/docs/reference/libraries).
+
+```
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "#path_to_json_credential_file"
+```
+
+Edit the script to put in the appropriate SQL string above. Update the project with the id from the previous step.
 
 ```
 client = bigquery.Client(project="change-to-your-project-id")

--- a/bigquery.py
+++ b/bigquery.py
@@ -16,10 +16,12 @@
 
 """ Query the BigQuery public table for the Metropolitan Art. """
 
-import uuid
+import uuid, os
 
 from google.cloud import bigquery
 
+# Specify path to generated environment variable json for project 
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "#path_to_json_credential_file"
 
 def query_metart():
     # Specify your Google Cloud project to connect to


### PR DESCRIPTION
To get users to implementing the project quicker and less likelihood of stalling progress. They can specify the path to the generated credentials within project. Users can have multiple projects that can require different credentials.